### PR TITLE
add support for Cordova 3.5.x (Issue #5)

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -18,6 +18,10 @@
   <!-- ios -->
   <platform name="ios">
 
+    <js-module src="www/wkwebview.js" name="wkwebview">
+        <clobbers target="wkwebview" />
+    </js-module>
+    
     <config-file target="config.xml" parent="/*">
       <feature name="WKWebViewPolyfill">
         <param name="ios-package" value="WKWebViewPolyfill"/>

--- a/www/wkwebview.js
+++ b/www/wkwebview.js
@@ -1,0 +1,67 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+if(!cordova.exec.jsToNativeModes.WK_WEBVIEW_BINDING) {
+
+	//
+	//intercept iframe bridge
+	//
+
+	var exec = require('cordova/exec');
+
+	//force bridge to be created with invalid message
+	try{
+		exec(null, null, 'WKWebView', '', []);
+	} catch(e) {}
+	
+	//wrap nativeFetchMessages with redirect to wkwebview bridge
+	var origNativeFetchMessages = exec.nativeFetchMessages;
+	exec.nativeFetchMessages = function() {
+		var cmds = origNativeFetchMessages();
+		cmds = JSON.parse(cmds);
+		for(var i=0;i<cmds.length;i++) {
+			var cmd = cmds[i];
+			if(cmd[1]==='WKWebView') continue;
+
+			window.webkit.messageHandlers.cordova.postMessage(cmd);
+		}
+		return '';
+	}
+
+	//get ref to bridge
+	var bridge;
+	var ifrs = document.getElementsByTagName('iframe');
+	for(var i=0;i<ifrs.length;i++) {
+		var ifr = ifrs[i];
+		if(ifr.style.display==='none') {
+			bridge = ifr;
+			break;
+		}
+	}
+
+	//add setter that calls (wrapped) nativeFetchMessages
+	ifr.__defineSetter__ ('src', function(val){
+		exec.nativeFetchMessages();
+	});
+
+	//make our setter be called
+	ifr.src="";
+}


### PR DESCRIPTION
Not sure if it completely fixes #5, but it fixes 3.5.0.
Also will fix #13 (at least for 3.5.0 builds).

I investigated why this was not working with Cordova 3.5 and found that a new js to native bridge was added in Cordova 3.6.0 (?) to support WKWebView.  Here's the commit: https://github.com/apache/cordova-js/commit/0329464c7bb538cc469dc965e28f5801ea14422f

I read some discussion in one of the issues as well as the readme (deviceready never fires with 3.5.0 due to a currently unknown reason) regarding 3.5.0 and thought you might be interested in a trying this fix out.
