### PR TITLE
Only fill in cacheFolder path string one time.

### DIFF
--- a/src/ios/MyMainViewController.m
+++ b/src/ios/MyMainViewController.m
@@ -239,7 +239,7 @@
   
   // Copy UIWebView to WKWebView so upgrading to the new webview is less of a pain in the ..
   NSString* appLibraryFolder = [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES) objectAtIndex:0];
-  NSString* cacheFolder = [appLibraryFolder stringByAppendingPathComponent:@"Caches"];
+  NSString* cacheFolder;
 
   if ([[NSFileManager defaultManager] fileExistsAtPath:[appLibraryFolder stringByAppendingPathComponent:@"WebKit/LocalStorage/file__0.localstorage"]]) {
     cacheFolder = [appLibraryFolder stringByAppendingPathComponent:@"WebKit/LocalStorage"];


### PR DESCRIPTION
As is, `cacheFolder` is filled in twice (the second time it is overwritten).  The first time is unneeded.
