### PR TITLE
#41: Added crash recovery support to battle white-screens 

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -48,6 +48,7 @@
     <source-file src="src/ios/MyMainViewController.m"/>
 
     <!-- the class which swaps in our controller and offers helper methods for the JS API -->
+    <source-file src="src/ios/AppDelegate+WKWebViewPolyfill.h"/>
     <source-file src="src/ios/AppDelegate+WKWebViewPolyfill.m"/>
 
     <!-- helper classes -->

--- a/src/ios/AppDelegate+WKWebViewPolyfill.h
+++ b/src/ios/AppDelegate+WKWebViewPolyfill.h
@@ -1,0 +1,14 @@
+//
+//  AppDelegate+WKWebViewPolyfill.h
+//
+//  Created by Hein Rutjes on X-mas eve
+//
+//
+
+#import "AppDelegate.h"
+
+@interface AppDelegate (WKWebViewPolyfill)
+
+- (void) createWindowAndStartWebServer:(BOOL) startWebServer;
+
+@end

--- a/src/ios/AppDelegate+WKWebViewPolyfill.m
+++ b/src/ios/AppDelegate+WKWebViewPolyfill.m
@@ -21,6 +21,11 @@ NSMutableDictionary* _webServerOptions;
 }
 
 - (BOOL)my_application:(UIApplication*)application didFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
+    [self createWindowAndStartWebServer:true];
+    return YES;
+}
+
+- (void) createWindowAndStartWebServer:(BOOL) startWebServer {
     CGRect screenBounds = [[UIScreen mainScreen] bounds];
 
     self.window = [[UIWindow alloc] initWithFrame:screenBounds];
@@ -44,12 +49,12 @@ NSMutableDictionary* _webServerOptions;
                       allowRangeRequests:YES];
 
     // Initialize Server startup
-    [self startServer];
+    if (startWebServer) {
+        [self startServer];
+    }
     
     // Update Swizzled ViewController with port currently used by local Server
     [myMainViewController setServerPort:_webServer.port];
-
-    return YES;
 }
 
 - (BOOL)identity_application: (UIApplication *)application

--- a/src/ios/MyMainViewController.m
+++ b/src/ios/MyMainViewController.m
@@ -7,6 +7,7 @@
 #import <Cordova/CDVURLProtocol.h>
 #import "CDVWebViewUIDelegate.h"
 #import "ReroutingUIWebView.h"
+#import "AppDelegate+WKWebViewPolyfill.h"
 
 @interface CDVViewController ()
 @property (nonatomic, readwrite, retain) NSArray *startupPluginNames;
@@ -17,6 +18,8 @@
   CDVWebViewDelegate* _webViewDelegate;
   CDVWebViewUIDelegate* _webViewUIDelegate;
   BOOL _targetExistsLocally;
+  NSTimer* _crashRecoveryTimer;
+  BOOL _crashRecoveryActive;
 }
 @end
 
@@ -71,6 +74,26 @@
   self.webView.hidden = true;
   [self.view addSubview:self.webView];
   [self.view sendSubviewToBack:self.webView];
+}
+
+- (void)recoverFromCrash
+{
+    // When an empty title is returned, WkWebView has crashed
+    NSString* title = self.wkWebView.title;
+    if ((title == nil) || [title isEqualToString:@""]) {
+        if (_crashRecoveryActive) {
+            NSLog(@"WkWebView crash detected, recovering... ");
+            _crashRecoveryActive = false;
+            [_crashRecoveryTimer invalidate];
+            _crashRecoveryTimer = nil;
+            AppDelegate* appDelegate = (AppDelegate*)[[UIApplication sharedApplication] delegate];
+            [appDelegate createWindowAndStartWebServer:false];
+        }
+    } else {
+        
+        // Once the title has been reported back as valid, activate crash recovery
+        _crashRecoveryActive = true;
+    }
 }
 
 - (id)settingForKey:(NSString*)key
@@ -434,6 +457,11 @@
     }];
   } else {
     // we'll load once the HTTP server starts.
+  }
+
+  // Start timer which periodically checks whether the app is alive
+  if ([self settingForKey:@"RecoverFromCrash"] && [[self settingForKey:@"RecoverFromCrash"] boolValue]) {
+    _crashRecoveryTimer = [NSTimer scheduledTimerWithTimeInterval:1 target:self selector:@selector(recoverFromCrash) userInfo:nil repeats:YES];
   }
 }
 


### PR DESCRIPTION
To enable crash recovery, set 'RecoverFromCrash' to true in config.xml:

```xml
<preference name="RecoverFromCrash" value="true" />
```

Important:
The check that is used for checking whether the WkWebView has crashed is very rudimentary and most likely inappropriate for other situations. It checks whether the wkwebview 'title' returns an empty string, and if that is the case, it assumed a crash and starts recovery.

to test:
create a small web-app and create a div with a large image every 200ms or so, and you should see it crash pretty quickly.