### PR TITLE
Adding a cache server to access folder with in the apps sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ _BETA_ - things may break, [please post your feedback :)](https://github.com/Edd
 
 * [Ionic](http://ionicframework.com/) tip: to prevent flashes of a black background, make sure you set `ion-nav-view`'s `background-color` to `transparent`.
 * If you need the [device plugin](org.apache.cordova.device), use at least Cordova-iOS 3.6.3 (deviceready never fires with 3.5.0 due to a currently unknown reason).
+* When making AJAX requests to a remote server make sure it supports CORS. See the [Telerik Verified Marketplace documentation](http://plugins.telerik.com/plugin/wkwebview) for more details on this and other valuable pointers.
 
 ## 2. Screenshot
 This image shows the [SocialSharing plugin](https://github.com/EddyVerbruggen/SocialSharing-PhoneGap-Plugin) in action while running [a performance test](https://www.scirra.com/demos/c2/particles/) in an iframe on my iPhone 6 (older devices show an even larger difference).

--- a/src/ios/MyMainViewController.h
+++ b/src/ios/MyMainViewController.h
@@ -13,6 +13,8 @@
 @property (nonatomic, readwrite, copy) NSString* uiWebViewLS;
 @property (nonatomic, readwrite, copy) NSString* wkWebViewLS;
 
+@property (nonatomic, readwrite, copy) NSString* cacheFolderName;
+
 @property (nonatomic, readwrite, assign) BOOL alreadyLoaded;
 
 - (void)loadURL:(NSURL*)URL;

--- a/www/wkwebview.js
+++ b/www/wkwebview.js
@@ -31,7 +31,7 @@ if(!cordova.exec.jsToNativeModes.WK_WEBVIEW_BINDING) {
 	try{
 		exec(null, null, 'WKWebView', '', []);
 	} catch(e) {}
-	
+
 	//wrap nativeFetchMessages with redirect to wkwebview bridge
 	var origNativeFetchMessages = exec.nativeFetchMessages;
 	exec.nativeFetchMessages = function() {
@@ -79,3 +79,17 @@ if(!cordova.exec.jsToNativeModes.WK_WEBVIEW_BINDING) {
 		}
 	};
 }
+
+// TODO: Have a way of fetching the given URLs for the server and the cache paths
+// as the ports are generated kinda randomly.
+//
+// var WKWebView = {
+// 	getWWWUrl = function () {
+// 		cordova.exec(null, null, "WKWebView", "getWWWUrl", []);
+// 	},
+// 	getCacheUrl = function () {
+// 		cordova.exec(null, null, "WKWebView", "getCacheUrl", []);
+// 	}
+// };
+
+// module.exports = WKWebView;


### PR DESCRIPTION
#### Overview

This is a quick work around to provide access to the apps sandbox of folders.

Normally the cache server can be access via http://localhost:12345. I've only used as a way to fix the issues [imgcache.js](https://github.com/chrisben/imgcache.js) has with using WKWebView.

Here's the simple function I use to translate a file:// url into one served by the cache folder

```js
function convertCacheDest(dest) {
  var found = dest.indexOf('imgcache');
  if (cordova.exec.jsToNativeModes.WK_WEBVIEW_BINDING && dest.indexOf('imgcache')) {
    return 'http://localhost:12345/Documents/' + dest.substring(found);
  }
  return dest;
}
```

You guys have a much better idea of how this should be handled I'm sure but I just wanted to float the idea with you. It's working for my use case with imgcache.js in ionic. Any advise on what to change would be appreciated

#### Related issues 

#22 

#### TODO

There needs to be a few nicer functions exposes to find the location of the cache server. Also having a translation function provided would be nice

Apologies for the mass whitespace removal :)