### PR TITLE
Restart web server during crash recovery.

### DIFF
--- a/src/ios/MyMainViewController.m
+++ b/src/ios/MyMainViewController.m
@@ -132,7 +132,7 @@
             [_crashRecoveryTimer invalidate];
             _crashRecoveryTimer = nil;
             AppDelegate* appDelegate = (AppDelegate*)[[UIApplication sharedApplication] delegate];
-            [appDelegate createWindowAndStartWebServer:false];
+            [appDelegate createWindowAndStartWebServer:true];
         }
     } else {
 


### PR DESCRIPTION
- Crash recovery for our application required setting `createWindowAndStartWebServer` to true.
- In response to the thread here: #62