### PR TITLE
Fix to make the wkWebView work with the cordova-plugin-keyboard.

### DIFF
--- a/src/ios/MyMainViewController.m
+++ b/src/ios/MyMainViewController.m
@@ -110,9 +110,13 @@
   self.wkWebView = [self newCordovaWKWebViewWithFrame:webViewBounds wkWebViewConfig:config];
   self.wkWebView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
 
-  // avoid the white flash while opening the app
   [self.wkWebView setOpaque:NO];
-  self.wkWebView.backgroundColor = [UIColor clearColor];
+  NSString* setting = @"BackgroundColor";
+  if ([self settingForKey:setting]) {
+      self.wkWebView.backgroundColor = [self colorFromHexString:[self settingForKey:setting]];
+  } else {
+      self.wkWebView.backgroundColor = [UIColor whiteColor];
+  }
 
   _webViewOperationsDelegate = [[CDVWebViewOperationsDelegate alloc] initWithWebView:self.webView];
 
@@ -577,5 +581,14 @@
   [self.commandQueue  execute:command];
 }
 #endif /* ifdef __IPHONE_8_0 */
+
+#pragma mark Color Utility
+// Assumes input like "0xFF00FF00" (0xAARRGGBB).
+- (UIColor *)colorFromHexString:(NSString *)hexString {
+    unsigned rgbValue = 0;
+    NSScanner *scanner = [NSScanner scannerWithString:hexString];
+    [scanner scanHexInt:&rgbValue];
+    return [UIColor colorWithRed:((rgbValue & 0xFF0000) >> 16)/255.0 green:((rgbValue & 0xFF00) >> 8)/255.0 blue:(rgbValue & 0xFF)/255.0 alpha:((rgbValue & 0xFF000000) >> 24)/255.0];
+}
 
 @end

--- a/src/ios/ReroutingUIWebView.m
+++ b/src/ios/ReroutingUIWebView.m
@@ -20,4 +20,13 @@
   [self.wkWebView addSubview:view];
 }
 
+- (void)layoutSubviews {
+    self.wkWebView.frame = self.frame;
+    self.wkWebView.scrollView.delegate = self;
+}
+
+- (void)scrollViewDidScroll:(UIScrollView *)scrollView {
+    [self.scrollView.delegate scrollViewDidScroll:scrollView];
+}
+
 @end


### PR DESCRIPTION
- The `cordova-plugin-keyboard` changes the frame of the `ReroutingUIWebView.m` which in turn triggers `layoutSubview` where I change the underlying `wkWebView` to be the right size. As a bonus, this should work for all other plugins that change the frame of the webview.
- When the keyboard comes up or the user taps a key, the `wkWebView`'s `scrollView` gets offset by some calculated height. To disable this the `cordova-plugin-keyboard` adds a delegate to the `ReroutingUIWebView`'s scrollView which resets the offset to 0. We need this to apply to the `wkWebView`'s scrollView so I added a delegate that passes the command down to `cordova-plugin-keyboard`'s delegate.