### PR TITLE
Simplify the fix in 31f0cc33.  This fixes multiple keyboard/sizing issues in WKWebView

### DIFF
--- a/src/ios/ReroutingUIWebView.h
+++ b/src/ios/ReroutingUIWebView.h
@@ -4,6 +4,7 @@
 @interface ReroutingUIWebView : UIWebView {
 }
 
+@property (nonatomic, readonly, retain, strong) UIScrollView *scrollView;
 @property (nonatomic, strong) IBOutlet WKWebView* wkWebView;
 
 @end

--- a/src/ios/ReroutingUIWebView.m
+++ b/src/ios/ReroutingUIWebView.m
@@ -4,6 +4,15 @@
 // note that this is not the most elegant solution, but as a pragmatic fix it works nicely for my usecases
 @implementation ReroutingUIWebView
 
+@synthesize scrollView = _scrollView;
+
+// Override the referenced scrollView to use WKWebView's scroll view, this helps fix plugins that alter
+// the size of the UIScrollView (like the Keyboard Plugin)
+- (void) setWkWebView:(WKWebView *)wkWebView{
+    _scrollView = wkWebView.scrollView;
+    _wkWebView = wkWebView;
+}
+
 // because plugins send their result to the UIWebView, this method reroutes this data to the WKWebView
 - (NSString *)stringByEvaluatingJavaScriptFromString:(NSString *)script {
   [self.wkWebView evaluateJavaScript:script completionHandler:nil];
@@ -19,14 +28,8 @@
 - (void)addSubview:(UIView *)view {
   [self.wkWebView addSubview:view];
 }
-
 - (void)layoutSubviews {
     self.wkWebView.frame = self.frame;
-    self.wkWebView.scrollView.delegate = self;
-}
-
-- (void)scrollViewDidScroll:(UIScrollView *)scrollView {
-    [self.scrollView.delegate scrollViewDidScroll:scrollView];
 }
 
 @end


### PR DESCRIPTION
Override the scrollView in UIReroutingiew to point to the one in the WKWevView so plugins can act directly on it

This also fixes an issue where the webview would be improperly sized after rotation & scrolling