### PR TITLE
Support byte ranges for requests

### DIFF
--- a/src/ios/AppDelegate+WKWebViewPolyfill.m
+++ b/src/ios/AppDelegate+WKWebViewPolyfill.m
@@ -85,7 +85,7 @@ NSString* appDataFolder;
                            return nil;
                        }
                          
-                       return [GCDWebServerFileResponse responseWithFile:fileLocation];
+                       return [GCDWebServerFileResponse responseWithFile:fileLocation byteRange:request.byteRange];
                      }
    ];
 }


### PR DESCRIPTION
Hi,

the "Library" and "Documents" handlers don't support byte range request (which was already implemented in the "main" handler, see https://github.com/swisspol/GCDWebServer/issues/27).

This fix should support these kind of requests for the additional handlers, too.

Cheers,
Thomas