### PR TITLE
fix iOS9 appURL issue with file protocol:

### DIFF
--- a/src/ios/MyMainViewController.m
+++ b/src/ios/MyMainViewController.m
@@ -261,7 +261,7 @@
 
   // iOS9 (runtime) compatibility
   if (IsAtLeastiOSVersion(@"9.0")) {
-    appURL = [NSURL URLWithString:[NSString stringWithFormat:@"file://%@/%@", self.wwwFolderName, self.startPage]];
+    appURL = [NSURL fileURLWithPath: [NSString stringWithFormat:@"file://%@/%@", self.wwwFolderName, self.startPage]];
   }
 
   // // Fix the iOS 5.1 SECURITY_ERR bug (CB-347), this must be before the webView is instantiated ////


### PR DESCRIPTION
looks like URLWithString return nil with file:// protocol
see http://stackoverflow.com/questions/2112927/urlwithstring-returns-nil-for-resource-path-iphone