### PR TITLE
Updated path handler registration

### DIFF
--- a/src/ios/AppDelegate+WKWebViewPolyfill.m
+++ b/src/ios/AppDelegate+WKWebViewPolyfill.m
@@ -71,7 +71,7 @@ NSString* appDataFolder;
 
 - (void)addHandlerForPath:(NSString *) path {
   [_webServer addHandlerForMethod:@"GET"
-                        pathRegex:[@".*" stringByAppendingString:path]
+                     pathRegex: [NSString stringWithFormat:@"^%@.*", path]
                      requestClass:[GCDWebServerRequest class]
                      processBlock:^GCDWebServerResponse *(GCDWebServerRequest* request) {
                        NSString *fileLocation = request.URL.path;


### PR DESCRIPTION
Make sure a path handler only applies when matching from start.

Previously affected path segments:
- /Documents
- /Library
- /tmp

E.g. 
`/directory/library/file.ext` is handled by the GET handler for local `www` (addGETHandlerForBasePath) and not by the handler registered for the path `/Library`.