### PR TITLE
Bugfix: didn't work if index.html wasn't in the docRoot

### DIFF
--- a/src/ios/AppDelegate+WKWebViewPolyfill.m
+++ b/src/ios/AppDelegate+WKWebViewPolyfill.m
@@ -43,7 +43,7 @@ NSString* appDataFolder;
 
     // Note: the embedded webserver is still needed for iOS 9. It's not needed to load index.html,
     //       but we need it to ajax-load files (file:// protocol has no origin, leading to CORS issues).
-    NSString *directoryPath = myMainViewController.wwwFolderName;
+    NSString *directoryPath = myMainViewController.docRoot;
     _webServer = [[GCDWebServer alloc] init];
     _webServerOptions = [NSMutableDictionary dictionary];
 
@@ -79,12 +79,12 @@ NSString* appDataFolder;
                        if ([fileLocation hasPrefix:path]) {
                          fileLocation = [appDataFolder stringByAppendingString:request.URL.path];
                        }
-                       
+
                        fileLocation = [fileLocation stringByReplacingOccurrencesOfString:FileSchemaConstant withString:@""];
                        if (![[NSFileManager defaultManager] fileExistsAtPath:fileLocation]) {
                            return nil;
                        }
-                         
+
                        return [GCDWebServerFileResponse responseWithFile:fileLocation byteRange:request.byteRange];
                      }
    ];

--- a/src/ios/MyMainViewController.h
+++ b/src/ios/MyMainViewController.h
@@ -11,6 +11,7 @@
 
 @property (nonatomic, readwrite, copy) NSString* uiWebViewLS;
 @property (nonatomic, readwrite, copy) NSString* wkWebViewLS;
+@property (nonatomic, readwrite, copy) NSString* docRoot;
 
 @property (nonatomic, strong) NSURL* url;
 @property (nonatomic, assign) BOOL pageLoaded;

--- a/src/ios/MyMainViewController.m
+++ b/src/ios/MyMainViewController.m
@@ -38,8 +38,9 @@
     NSString* startFilePath = [self.commandDelegate pathForResource:[startURL path]];
     _targetExistsLocally = [[NSFileManager defaultManager]
                              fileExistsAtPath:startFilePath];
-    startFilePath = [startFilePath stringByDeletingLastPathComponent];
-    self.wwwFolderName = startFilePath;
+    NSRange range = [startFilePath rangeOfString:self.startPage options:NSBackwardsSearch];
+    NSString* docRoot = [startFilePath substringToIndex:range.location];
+    self.docRoot = docRoot;
     self.alreadyLoaded = false;
   }
 
@@ -393,7 +394,7 @@
     if ([self.webView respondsToSelector:@selector(setKeyboardDisplayRequiresUserAction:)]) {
       [self.webView setValue:[NSNumber numberWithBool:keyboardDisplayRequiresUserAction] forKey:@"keyboardDisplayRequiresUserAction"];
     }
-    
+
     if (!keyboardDisplayRequiresUserAction) {
       [self keyboardDisplayDoesNotRequireUserAction];
     }


### PR DESCRIPTION
Specifically, it set the docRoot to the folder index.html was in, but then it used the full path for index.html for document.location. 