### PR TITLE
Support file:// urls

### DIFF
--- a/src/ios/MyMainViewController.m
+++ b/src/ios/MyMainViewController.m
@@ -244,6 +244,14 @@
   } else {
     if ([self.startPage hasPrefix:@"http"]) {
       _startURL = [NSURL URLWithString:self.startPage];
+    } else if ([self.startPage hasPrefix:@"file"]) {
+      NSString* fixedStartPage = [self.startPage stringByReplacingOccurrencesOfString:@"file://" withString:@""];
+      fixedStartPage = [fixedStartPage stringByReplacingOccurrencesOfString:NSHomeDirectory() withString:@""];
+      
+      _startURL = [NSURL URLWithString:[NSString stringWithFormat:
+                                        @"http://localhost:%hu%@",
+                                        port,
+                                        fixedStartPage]];
     } else {
       _startURL = [NSURL URLWithString:[NSString stringWithFormat:
                                               @"http://localhost:%hu/%@",


### PR DESCRIPTION
Some plugins can set a file:// url that is the absolute path of a file, for example cordova-hot-code-push-plugin tries to set the start page as:

`file:///Users/user/Library/Developer/CoreSimulator/Devices/EC1D4B9C-9582-4592-AD29-988B1D2C9247/data/Containers/Data/Application/D4B4B4EF-4C96-4D52-976C-565FEB50DEF3/Library/Application%20Support/app.bundle.name/cordova-hot-code-push-plugin/www/index.html`

This makes this plugin try to set this url: `http://localhost:12344/file:///Users/user/Library/Developer/CoreSimulator/Devices/EC1D4B9C-9582-4592-AD29-988B1D2C9247/data/Containers/Data/Application/D4B4B4EF-4C96-4D52-976C-565FEB50DEF3/Library/Application%20Support/app.bundle.name/cordova-hot-code-push-plugin/www/index.html`

The change checks for file:// urls and does some normalization on them so you end up with: `http://localhost:12344/Library/Application%20Support/app.bundle.name/cordova-hot-code-push-plugin/www/index.html`

See https://github.com/nordnet/cordova-hot-code-push/issues/42