### PR TITLE
Allow plugins to reload the webview

### DIFF
--- a/src/ios/MyMainViewController.h
+++ b/src/ios/MyMainViewController.h
@@ -16,9 +16,11 @@
 @property (nonatomic, assign) BOOL pageLoaded;
 
 @property (nonatomic, readwrite, assign) BOOL alreadyLoaded;
+@property (nonatomic, assign) unsigned short port;
 
 - (void)loadURL:(NSURL*)URL;
 - (void)copyLS:(unsigned short)httpPort;
 - (void)setServerPort:(unsigned short) port;
+- (NSURL*)fixURL:(NSString*)URL;
 
 @end

--- a/src/ios/MyMainViewController.m
+++ b/src/ios/MyMainViewController.m
@@ -236,28 +236,27 @@
     }];
 }
 
+- (NSURL*)fixURL:(NSString*)URL
+{
+  if ([URL hasPrefix:@"http"]) {
+    return [NSURL URLWithString:URL];
+  } else if ([URL hasPrefix:@"file"]) {
+    NSString* fixedStartPage = [URL stringByReplacingOccurrencesOfString:@"file://" withString:@""];
+    fixedStartPage = [fixedStartPage stringByReplacingOccurrencesOfString:NSHomeDirectory() withString:@""];
+    return [NSURL URLWithString:[NSString stringWithFormat:@"http://localhost:%hu%@", self.port, fixedStartPage]];
+  } else {
+    return [NSURL URLWithString:[NSString stringWithFormat:@"http://localhost:%hu/%@", self.port, URL]];
+  }
+}
+
 - (void)setServerPort:(unsigned short)port
 {
   if (self.alreadyLoaded) {
     // If we already loaded for some reason, we don't care about the local port.
     return;
   } else {
-    if ([self.startPage hasPrefix:@"http"]) {
-      _startURL = [NSURL URLWithString:self.startPage];
-    } else if ([self.startPage hasPrefix:@"file"]) {
-      NSString* fixedStartPage = [self.startPage stringByReplacingOccurrencesOfString:@"file://" withString:@""];
-      fixedStartPage = [fixedStartPage stringByReplacingOccurrencesOfString:NSHomeDirectory() withString:@""];
-      
-      _startURL = [NSURL URLWithString:[NSString stringWithFormat:
-                                        @"http://localhost:%hu%@",
-                                        port,
-                                        fixedStartPage]];
-    } else {
-      _startURL = [NSURL URLWithString:[NSString stringWithFormat:
-                                              @"http://localhost:%hu/%@",
-                                              port,
-                                              self.startPage]];
-    }
+    self.port = port;
+    _startURL = [self fixURL:self.startPage];
     [self loadURL:_startURL];
   }
 }
@@ -405,7 +404,7 @@
     if ([self.webView respondsToSelector:@selector(setKeyboardDisplayRequiresUserAction:)]) {
       [self.webView setValue:[NSNumber numberWithBool:keyboardDisplayRequiresUserAction] forKey:@"keyboardDisplayRequiresUserAction"];
     }
-    
+
     if (!keyboardDisplayRequiresUserAction) {
       [self keyboardDisplayDoesNotRequireUserAction];
     }
@@ -569,6 +568,7 @@
 
   ReroutingUIWebView *e = [[ReroutingUIWebView alloc] initWithFrame:bounds];
   e.wkWebView = cordovaView;
+  e.viewController = self;
   self.webView = e;
   return cordovaView;
 }

--- a/src/ios/ReroutingUIWebView.h
+++ b/src/ios/ReroutingUIWebView.h
@@ -1,10 +1,11 @@
 #import <Foundation/Foundation.h>
 #import <WebKit/WKWebView.h>
+#import "MyMainViewController.h"
 
 @interface ReroutingUIWebView : UIWebView {
 }
 
 @property (nonatomic, readonly, retain, strong) UIScrollView *scrollView;
 @property (nonatomic, strong) IBOutlet WKWebView* wkWebView;
-
+@property (nonatomic, strong) MyMainViewController* viewController;
 @end

--- a/src/ios/ReroutingUIWebView.m
+++ b/src/ios/ReroutingUIWebView.m
@@ -34,7 +34,10 @@
 
 // Ionic's Deploy plugin uses this
 - (void)loadRequest:(NSURLRequest*)request {
-    [self.wkWebView loadRequest:request];
+    NSMutableURLRequest *mutableRequest = [request mutableCopy];
+    NSString *urlString = [request.URL absoluteString];
+    mutableRequest.URL = [self.viewController fixURL:urlString];
+    [self.wkWebView loadRequest:mutableRequest];
 }
 
 @end


### PR DESCRIPTION
This improves on #195 by making the same URL fixes prior to reloading the web view when a plugin calls `webview.loadRequest`. 

Without this, a broken URL would be assigned to the webview and reloading would not work properly.