### PR TITLE
Default behavior should not be enabling crash recovery race condition

### DIFF
--- a/src/ios/MyMainViewController.m
+++ b/src/ios/MyMainViewController.m
@@ -523,7 +523,8 @@
   }
 
   // Start timer which periodically checks whether the app is alive
-  if (![self settingForKey:@"DisableCrashRecovery"] || ![[self settingForKey:@"DisableCrashRecovery"] boolValue]) {
+  if ([[self settingForKey:@"EnableCrashRecovery"] boolValue]) {
+    NSLog(@"NOTICE: Crash recovery enabled, this relies on checking page title and a blank title can trigger recovery");
     _crashRecoveryTimer = [NSTimer scheduledTimerWithTimeInterval:1 target:self selector:@selector(recoverFromCrash) userInfo:nil repeats:YES];
   }
 }


### PR DESCRIPTION
Current incarnation of crash recovery is causes race conditions triggering crashes in many Ionic applications and other single-page apps.

People using crash recovery feature should be aware of how it works to avoid race condition crashes until a better solution can be found.