### PR TITLE
Update web view frame when super view changes its size.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.6.9",
+    "version": "0.6.10",
     "name": "cordova-plugin-wkwebview",
     "cordova_name": "WKWebView Polyfill",
     "description": "A drop-in replacement of UIWebView for boosted performance and enhanced HTML5 support",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         id="com.telerik.plugins.wkwebview"
-        version="0.6.9">
+        version="0.6.10">
 
   <name>WKWebView Polyfill</name>
 

--- a/src/ios/MyMainViewController.m
+++ b/src/ios/MyMainViewController.m
@@ -103,6 +103,18 @@
   }
 }
 
+#pragma mark View Rotation Event Handling
+
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
+{
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+
+    [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {
+        self.wkWebView.frame = self.view.bounds;
+        [self.wkWebView layoutIfNeeded];
+    } completion:nil];
+}
+
 #pragma mark View lifecycle
 
 - (void)createGapView:(WKWebViewConfiguration*) config


### PR DESCRIPTION
For some reason the 'autoresizingMask' property does not work as expected
when a Cordova project is built with Xcode 7.3 (latest iOS 9 SDK) and deployed
on device running on iOS 10. This results in web view not updating its frame
on rotation events.

In order to resolve the issue, implement 'viewWillTransitionToSize:withTransitionCoordinator:'
(iOS 8.0 and later) and layout the web view with updated frame.

Issue: https://github.com/Telerik-Verified-Plugins/WKWebView/issues/260
ping @EddyVerbruggen @galexandrov @TomaNikolov 